### PR TITLE
setup: internationalization

### DIFF
--- a/lib/lang/l10n/intl_messages.arb
+++ b/lib/lang/l10n/intl_messages.arb
@@ -1,0 +1,19 @@
+{
+  "@@last_modified": "2020-08-13T13:08:32.831027",
+  "title": "Kledd",
+  "@title": {
+    "description": "App title",
+    "type": "text",
+    "placeholders": {}
+  },
+  "signInButtonText": "Sign in with {service}",
+  "@signInButtonText": {
+    "description": "Text on sign in button",
+    "type": "text",
+    "placeholders": {
+      "service": {
+        "example": "Google"
+      }
+    }
+  }
+}

--- a/lib/lang/l10n/intl_messages_en.arb
+++ b/lib/lang/l10n/intl_messages_en.arb
@@ -1,0 +1,20 @@
+{
+  "@@locale": "en",
+  "@@last_modified": "2020-08-12T14:14:03.884339",
+  "title": "Kledd",
+  "@title": {
+    "description": "App title",
+    "type": "text",
+    "placeholders": {}
+  },
+  "signInButtonText": "Sign in with {service}",
+  "@signInButtonText": {
+    "description": "Text on sign in button",
+    "type": "text",
+    "placeholders": {
+      "service": {
+        "example": "Google"
+      }
+    }
+  }
+}

--- a/lib/lang/l10n/intl_messages_sv.arb
+++ b/lib/lang/l10n/intl_messages_sv.arb
@@ -1,0 +1,20 @@
+{
+  "@@locale": "sv",
+  "@@last_modified": "2020-08-12T14:14:03.884339",
+  "title": "Kledd",
+  "@title": {
+    "description": "App title",
+    "type": "text",
+    "placeholders": {}
+  },
+  "signInButtonText": "Logga in med {service}",
+  "@signInButtonText": {
+    "description": "Text on sign in button",
+    "type": "text",
+    "placeholders": {
+      "service": {
+        "example": "Google"
+      }
+    }
+  }
+}

--- a/lib/lang/l10n/messages_all.dart
+++ b/lib/lang/l10n/messages_all.dart
@@ -1,0 +1,71 @@
+// DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
+// This is a library that looks up messages for specific locales by
+// delegating to the appropriate library.
+
+// Ignore issues from commonly used lints in this file.
+// ignore_for_file:implementation_imports, file_names, unnecessary_new
+// ignore_for_file:unnecessary_brace_in_string_interps, directives_ordering
+// ignore_for_file:argument_type_not_assignable, invalid_assignment
+// ignore_for_file:prefer_single_quotes, prefer_generic_function_type_aliases
+// ignore_for_file:comment_references
+
+import 'dart:async';
+
+import 'package:intl/intl.dart';
+import 'package:intl/message_lookup_by_library.dart';
+import 'package:intl/src/intl_helpers.dart';
+
+import 'messages_messages.dart' deferred as messages_messages;
+import 'messages_en.dart' deferred as messages_en;
+import 'messages_sv.dart' deferred as messages_sv;
+
+typedef Future<dynamic> LibraryLoader();
+Map<String, LibraryLoader> _deferredLibraries = {
+  'messages': messages_messages.loadLibrary,
+  'en': messages_en.loadLibrary,
+  'sv': messages_sv.loadLibrary,
+};
+
+MessageLookupByLibrary _findExact(String localeName) {
+  switch (localeName) {
+    case 'messages':
+      return messages_messages.messages;
+    case 'en':
+      return messages_en.messages;
+    case 'sv':
+      return messages_sv.messages;
+    default:
+      return null;
+  }
+}
+
+/// User programs should call this before using [localeName] for messages.
+Future<bool> initializeMessages(String localeName) async {
+  var availableLocale = Intl.verifiedLocale(
+    localeName,
+    (locale) => _deferredLibraries[locale] != null,
+    onFailure: (_) => null);
+  if (availableLocale == null) {
+    return new Future.value(false);
+  }
+  var lib = _deferredLibraries[availableLocale];
+  await (lib == null ? new Future.value(false) : lib());
+  initializeInternalMessageLookup(() => new CompositeMessageLookup());
+  messageLookup.addLocale(availableLocale, _findGeneratedMessagesFor);
+  return new Future.value(true);
+}
+
+bool _messagesExistFor(String locale) {
+  try {
+    return _findExact(locale) != null;
+  } catch (e) {
+    return false;
+  }
+}
+
+MessageLookupByLibrary _findGeneratedMessagesFor(String locale) {
+  var actualLocale = Intl.verifiedLocale(locale, _messagesExistFor,
+      onFailure: (_) => null);
+  if (actualLocale == null) return null;
+  return _findExact(actualLocale);
+}

--- a/lib/lang/l10n/messages_en.dart
+++ b/lib/lang/l10n/messages_en.dart
@@ -1,0 +1,29 @@
+// DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
+// This is a library that provides messages for a en locale. All the
+// messages from the main program should be duplicated here with the same
+// function name.
+
+// Ignore issues from commonly used lints in this file.
+// ignore_for_file:unnecessary_brace_in_string_interps, unnecessary_new
+// ignore_for_file:prefer_single_quotes,comment_references, directives_ordering
+// ignore_for_file:annotate_overrides,prefer_generic_function_type_aliases
+// ignore_for_file:unused_import, file_names
+
+import 'package:intl/intl.dart';
+import 'package:intl/message_lookup_by_library.dart';
+
+final messages = new MessageLookup();
+
+typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
+
+class MessageLookup extends MessageLookupByLibrary {
+  String get localeName => 'en';
+
+  static m0(service) => "Sign in with ${service}";
+
+  final messages = _notInlinedMessages(_notInlinedMessages);
+  static _notInlinedMessages(_) => <String, Function> {
+    "signInButtonText" : m0,
+    "title" : MessageLookupByLibrary.simpleMessage("Kledd")
+  };
+}

--- a/lib/lang/l10n/messages_messages.dart
+++ b/lib/lang/l10n/messages_messages.dart
@@ -1,0 +1,29 @@
+// DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
+// This is a library that provides messages for a messages locale. All the
+// messages from the main program should be duplicated here with the same
+// function name.
+
+// Ignore issues from commonly used lints in this file.
+// ignore_for_file:unnecessary_brace_in_string_interps, unnecessary_new
+// ignore_for_file:prefer_single_quotes,comment_references, directives_ordering
+// ignore_for_file:annotate_overrides,prefer_generic_function_type_aliases
+// ignore_for_file:unused_import, file_names
+
+import 'package:intl/intl.dart';
+import 'package:intl/message_lookup_by_library.dart';
+
+final messages = new MessageLookup();
+
+typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
+
+class MessageLookup extends MessageLookupByLibrary {
+  String get localeName => 'messages';
+
+  static m0(service) => "Sign in with ${service}";
+
+  final messages = _notInlinedMessages(_notInlinedMessages);
+  static _notInlinedMessages(_) => <String, Function> {
+    "signInButtonText" : m0,
+    "title" : MessageLookupByLibrary.simpleMessage("Kledd")
+  };
+}

--- a/lib/lang/l10n/messages_sv.dart
+++ b/lib/lang/l10n/messages_sv.dart
@@ -1,0 +1,29 @@
+// DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
+// This is a library that provides messages for a sv locale. All the
+// messages from the main program should be duplicated here with the same
+// function name.
+
+// Ignore issues from commonly used lints in this file.
+// ignore_for_file:unnecessary_brace_in_string_interps, unnecessary_new
+// ignore_for_file:prefer_single_quotes,comment_references, directives_ordering
+// ignore_for_file:annotate_overrides,prefer_generic_function_type_aliases
+// ignore_for_file:unused_import, file_names
+
+import 'package:intl/intl.dart';
+import 'package:intl/message_lookup_by_library.dart';
+
+final messages = new MessageLookup();
+
+typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
+
+class MessageLookup extends MessageLookupByLibrary {
+  String get localeName => 'sv';
+
+  static m0(service) => "Logga in med ${service}";
+
+  final messages = _notInlinedMessages(_notInlinedMessages);
+  static _notInlinedMessages(_) => <String, Function> {
+    "signInButtonText" : m0,
+    "title" : MessageLookupByLibrary.simpleMessage("Kledd")
+  };
+}

--- a/lib/lang/my_localizations.dart
+++ b/lib/lang/my_localizations.dart
@@ -1,0 +1,49 @@
+import 'dart:async';
+
+import 'package:intl/intl.dart';
+import 'package:flutter/material.dart';
+
+import 'l10n/messages_all.dart';
+
+class MyLocalizations {
+  /// Initialize localization systems and messages
+  static Future<MyLocalizations> load(Locale locale) async {
+    // If we're given "en_US", we'll use it as-is. If we're
+    // given "en", we extract it and use it.
+    final String localeName =
+        locale.countryCode == null || locale.countryCode.isEmpty
+            ? locale.languageCode
+            : locale.toString();
+    // We make sure the locale name is in the right format e.g.
+    // converting "en-US" to "en_US".
+    final String canonicalLocaleName = Intl.canonicalizedLocale(localeName);
+    // Load localized messages for the current locale.
+    await initializeMessages(canonicalLocaleName);
+    // Force the locale in Intl.
+    Intl.defaultLocale = canonicalLocaleName;
+    return MyLocalizations();
+  }
+
+  /// Retrieve localization resources for the widget tree
+  /// corresponding to the given `context`
+  static MyLocalizations of(BuildContext context) =>
+      Localizations.of<MyLocalizations>(context, MyLocalizations);
+
+  // ----------------------
+  // Declare messages here.
+  // ----------------------
+
+  String get title => Intl.message(
+        'Kledd',
+        name: 'title',
+        desc: 'App title',
+      );
+
+  String signInButtonText(String service) => Intl.message(
+        'Sign in with $service',
+        name: 'signInButtonText',
+        args: [service],
+        desc: 'Text on sign in button',
+        examples: const {'service': 'Google'},
+      );
+}

--- a/lib/lang/my_localizations_delegate.dart
+++ b/lib/lang/my_localizations_delegate.dart
@@ -1,0 +1,19 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'my_localizations.dart';
+
+class MyLocalizationsDelegate extends LocalizationsDelegate<MyLocalizations> {
+  const MyLocalizationsDelegate();
+
+  @override
+  bool isSupported(Locale locale) => [
+        'en',
+        'sv',
+      ].contains(locale.languageCode);
+
+  @override
+  Future<MyLocalizations> load(Locale locale) => MyLocalizations.load(locale);
+
+  @override
+  bool shouldReload(LocalizationsDelegate<MyLocalizations> old) => false;
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 
 import 'screens/auth_screen.dart';
 import 'screens/splash_screen.dart';
 import 'screens/tab_screen.dart';
+import 'lang/my_localizations.dart';
+import 'lang/my_localizations_delegate.dart';
 
 void main() {
   runApp(MyApp());
@@ -13,7 +16,16 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Kledd',
+      onGenerateTitle: (context) => MyLocalizations.of(context).title,
+      localizationsDelegates: [
+        const MyLocalizationsDelegate(),
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ],
+      supportedLocales: [
+        const Locale('en'), // English (default)
+        const Locale('sv'), // Swedish
+      ],
       theme: ThemeData(
         primarySwatch: Colors.cyan,
         visualDensity: VisualDensity.adaptivePlatformDensity,

--- a/lib/screens/auth_screen.dart
+++ b/lib/screens/auth_screen.dart
@@ -23,7 +23,7 @@ class _AuthScreenState extends State<AuthScreen> {
           child: Align(
             alignment: Alignment.center,
             child: LoginButton(
-              title: 'Sign in with Google',
+              service: 'Google',
               onLoginUser: _handleGoogleSignIn,
             ),
           ),

--- a/lib/widgets/auth/login_button.dart
+++ b/lib/widgets/auth/login_button.dart
@@ -1,22 +1,28 @@
 import 'package:flutter/material.dart';
 
+import '../../lang/my_localizations.dart';
+
 class LoginButton extends StatelessWidget {
-  final String title;
+  final String service;
   final Function onLoginUser;
 
   LoginButton({
-    this.title,
+    this.service,
     this.onLoginUser,
   });
 
   @override
   Widget build(BuildContext context) {
+    final l10n = MyLocalizations.of(context);
+
     return RaisedButton(
       onPressed: onLoginUser,
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(20),
       ),
-      child: Text(title),
+      child: Text(
+        l10n.signInButtonText(service),
+      ),
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,11 +23,14 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-
   cupertino_icons: ^0.1.3
   cloud_firestore: ^0.13.7
   firebase_auth: ^0.16.1
   google_sign_in: ^4.5.1
+  flutter_localizations:
+    sdk: flutter
+  intl: ^0.16.1
+  intl_translation: ^0.17.10
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Support for English and Swedish has been added.

Instructions for adding new messages (Powershell):

1. Add the message to **lib/lang/my_localizations.dart**
2. Run `flutter pub pub run intl_translation:extract_to_arb --output-dir=lib/lang/l10n lib/lang/my_localizations.dart`
3. Add the newly created messages in **lib/lang/l10n/intl_messages.arb** to **lib/lang/l10n/intl_messages_en.arb** and **lib/lang/l10n/intl_messages_sv.arb**
4. Run `flutter pub pub run intl_translation:generate_from_arb lib/lang/my_localizations.dart lib/lang/l10n/intl_messages.arb lib/lang/l10n/intl_messages_en.arb lib/lang/l10n/intl_messages_sv.arb  --output-dir=lib/lang/l10n`
5. Use message in code

For more information see this [guide](https://phrase.com/blog/posts/how-to-internationalize-a-flutter-app/) which I followed to implement this.