### PR TITLE
refactor: move show snackbar function to utils

### DIFF
--- a/lib/screens/auth_screen.dart
+++ b/lib/screens/auth_screen.dart
@@ -6,6 +6,7 @@ import 'package:kledd/models/authentication_service.dart';
 
 import '../widgets/auth/login_button.dart';
 import '../lang/my_localizations.dart';
+import '../utils/show_snackbar.dart';
 
 class AuthScreen extends StatefulWidget {
   @override
@@ -44,7 +45,10 @@ class _AuthScreenState extends State<AuthScreen> {
               authenticationService: AuthenticationService.GOOGLE,
               onLoginUser: () {
                 _handleGoogleSignIn().catchError(
-                  (e) => _showSnackbar(l10n.authFailed),
+                  (e) => showSnackbar(
+                    key: _scaffoldKey,
+                    message: l10n.authFailed,
+                  ),
                 );
               },
             ),
@@ -86,15 +90,6 @@ class _AuthScreenState extends State<AuthScreen> {
         'profile_image_url': user.photoUrl,
         'phone_number': user.phoneNumber,
       },
-    );
-  }
-
-  /// Shows a SnackBar with the given message.
-  void _showSnackbar(String message) {
-    _scaffoldKey.currentState.showSnackBar(
-      SnackBar(
-        content: Text(message),
-      ),
     );
   }
 }

--- a/lib/utils/show_snackbar.dart
+++ b/lib/utils/show_snackbar.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+/// Shows a SnackBar with the given message in the Scaffold with the given key.
+void showSnackbar({
+  @required GlobalKey<ScaffoldState> key,
+  @required String message,
+}) {
+  key.currentState.showSnackBar(
+    SnackBar(
+      content: Text(message),
+    ),
+  );
+}


### PR DESCRIPTION
Closes #51 

Note: This PR will need to be updated when #44 is accepted or vice versa to include `showSnackbar` in `tabScreen`.